### PR TITLE
处理 ol 与 echarts 的事件冲突

### DIFF
--- a/packages/ol-echarts/src/index.ts
+++ b/packages/ol-echarts/src/index.ts
@@ -144,7 +144,7 @@ class EChartsLayer extends obj {
     bindAll([
       'redraw', 'onResize', 'onZoomEnd', 'onCenterChange',
       'onDragRotateEnd', 'onMoveStart', 'onMoveEnd',
-      'mouseDown', 'mouseUp', 'onClick',
+      'mouseDown', 'mouseUp', 'onClick', 'mouseMove',
     ], this);
 
     if (map) this.setMap(map);
@@ -490,6 +490,25 @@ class EChartsLayer extends obj {
   }
 
   /**
+   * mousemove 事件需要分两种情况处理:
+   * 1. ol-overlaycontainer-stopevent 有高度, 则 propagation path 是 ol-viewport -> ol-overlaycontainer-stopevent. 此时 ol-overlaycontainer 无法获得事件, 只能 mock 处理
+   * 2. ol-overlaycontainer-stopevent 没有高度, 则 propagation path 是 ol-viewport -> ol-overlaycontainer. 无需 mock
+   * @param event
+   */
+  private mouseMove(event: any) {
+    if (this.$chart) {
+      let target = event.originalEvent.target;
+      while (target) {
+        if (target.className === 'ol-overlaycontainer-stopevent') {
+          this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mousemove', event));
+          return;
+        }
+        target = target.parentElement;
+      }
+    }
+  }
+
+  /**
    * handle center change
    */
   private onCenterChange() {
@@ -563,6 +582,7 @@ class EChartsLayer extends obj {
     if (this._options.polyfillEvents) {
       map.on('pointerdown', this.mouseDown);
       map.on('pointerup', this.mouseUp);
+      map.on('pointermove', this.mouseMove);
       map.on('click', this.onClick);
     }
     this._initEvent = true;
@@ -587,6 +607,7 @@ class EChartsLayer extends obj {
     if (this._options.polyfillEvents) {
       map.un('pointerdown', this.mouseDown);
       map.un('pointerup', this.mouseUp);
+      map.un('pointermove', this.mouseMove);
       map.un('click', this.onClick);
     }
     this._initEvent = false;

--- a/packages/ol-echarts/src/index.ts
+++ b/packages/ol-echarts/src/index.ts
@@ -464,8 +464,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private onClick(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('click', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('click', event));
     }
   }
 
@@ -474,8 +474,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private mouseDown(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('mousedown', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mousedown', event));
     }
   }
 
@@ -484,8 +484,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private mouseUp(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('mouseup', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mouseup', event));
     }
   }
 

--- a/packages/ol-echarts/src/utils/index.ts
+++ b/packages/ol-echarts/src/utils/index.ts
@@ -97,6 +97,10 @@ function removeNode(node: HTMLElement) {
  */
 function mockEvent(type: string, event: any) {
   const e = new MouseEvent(type, {
+    // set bubbles, so zrender can receive the mock event. ref: https://dom.spec.whatwg.org/#interface-event 
+    // "event.bubbles": Returns true or false depending on how event was initialized. True if event goes through its target’s ancestors in reverse tree order, and false otherwise
+    bubbles: true,
+    cancelable: true,
     button: event.pointerEvent.button,
     buttons: event.pointerEvent.buttons,
     clientX: event.pointerEvent.clientX,

--- a/packages/ol3-echarts/src/index.ts
+++ b/packages/ol3-echarts/src/index.ts
@@ -173,7 +173,7 @@ class EChartsLayer extends obj {
     bindAll([
       'redraw', 'onResize', 'onZoomEnd', 'onCenterChange',
       'onDragRotateEnd', 'onMoveStart', 'onMoveEnd',
-      'mouseDown', 'mouseUp', 'onClick',
+      'mouseDown', 'mouseUp', 'onClick', 'mouseMove',
     ], this);
 
     if (map) this.setMap(map);
@@ -519,6 +519,25 @@ class EChartsLayer extends obj {
   }
 
   /**
+   * mousemove 事件需要分两种情况处理:
+   * 1. ol-overlaycontainer-stopevent 有高度, 则 propagation path 是 ol-viewport -> ol-overlaycontainer-stopevent. 此时 ol-overlaycontainer 无法获得事件, 只能 mock 处理
+   * 2. ol-overlaycontainer-stopevent 没有高度, 则 propagation path 是 ol-viewport -> ol-overlaycontainer. 无需 mock
+   * @param event
+   */
+  private mouseMove(event: any) {
+    if (this.$chart) {
+      let target = event.originalEvent.target;
+      while (target) {
+        if (target.className === 'ol-overlaycontainer-stopevent') {
+          this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mousemove', event));
+          return;
+        }
+        target = target.parentElement;
+      }
+    }
+  }
+
+  /**
    * handle center change
    */
   private onCenterChange() {
@@ -592,6 +611,7 @@ class EChartsLayer extends obj {
     if (this._options.polyfillEvents) {
       map.on('pointerdown', this.mouseDown);
       map.on('pointerup', this.mouseUp);
+      map.on('pointermove', this.mouseMove);
       map.on('click', this.onClick);
     }
     this._initEvent = true;
@@ -616,6 +636,7 @@ class EChartsLayer extends obj {
     if (this._options.polyfillEvents) {
       map.un('pointerdown', this.mouseDown);
       map.un('pointerup', this.mouseUp);
+      map.un('pointermove', this.mouseMove);
       map.un('click', this.onClick);
     }
     this._initEvent = false;

--- a/packages/ol3-echarts/src/index.ts
+++ b/packages/ol3-echarts/src/index.ts
@@ -493,8 +493,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private onClick(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('click', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('click', event));
     }
   }
 
@@ -503,8 +503,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private mouseDown(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('mousedown', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mousedown', event));
     }
   }
 
@@ -513,8 +513,8 @@ class EChartsLayer extends obj {
    * @param event
    */
   private mouseUp(event: any) {
-    if (this.$container) {
-      this.$container.dispatchEvent(mockEvent('mouseup', event));
+    if (this.$chart) {
+      this.$chart.getZr().painter.getViewportRoot().dispatchEvent(mockEvent('mouseup', event));
     }
   }
 

--- a/packages/ol3-echarts/src/utils/index.ts
+++ b/packages/ol3-echarts/src/utils/index.ts
@@ -97,6 +97,10 @@ function removeNode(node: HTMLElement) {
  */
 function mockEvent(type: string, event: any) {
   const e = new MouseEvent(type, {
+    // set bubbles, so zrender can receive the mock event. ref: https://dom.spec.whatwg.org/#interface-event 
+    // "event.bubbles": Returns true or false depending on how event was initialized. True if event goes through its target’s ancestors in reverse tree order, and false otherwise
+    bubbles: true,
+    cancelable: true,
     button: event.pointerEvent.button,
     buttons: event.pointerEvent.buttons,
     clientX: event.pointerEvent.clientX,


### PR DESCRIPTION
fix #52 #45 #51 

两者的冲突并不是因为事件捕获到 ol-overlaycontainer-stopevent 就终止. 而是 ol 现在给 `ol-overlaycontainer-stopevent` 加上了 `position: absolute; z-index: 0; width: 100%; height: 100%;` 的样式.

这导致事件的 target 变成了 `ol-overlaycontainer-stopevent`. 所以事件的 [propagation path](https://www.w3.org/TR/DOM-Level-3-Events/#propagation-path) 变成了 `ol-viewport` -> `ol-overlaycontainer-stopevent`. `ol-overlaycontainer` 及其内部的 div 不在 propagation path 中, 所以无法获得事件.

处理方式就是 mock mousemove event, 不过得考虑两种情况:
1. `ol-viewport` -> `ol-overlaycontainer-stopevent`, 不在 propagation path 中, 需要 mock
2. `ol-viewport` -> `ol-overlaycontainer`. 处在 propagation path 中, 无需 mock

还有一个问题掺杂在这些 issue 中:  将 mock 的事件发送给 `this.$container` 是没有用的. 因为 zrender 的 `HandlerProxy` 监听的对象是 `this.$container` 的子 div. 而 `this.$container.dispatchEvent(mockEvent('mousedown', event))` 会将 mock 的 event 的 target 设置为 `this.$container`. 它的子 div 是无法得到 mock 的事件的. 因此需要直接对 zrender 的 painter 的 viewport root 元素 dispatchEvent 事件.

写了一个 [demo](https://codesandbox.io/s/ol-echarts-example-hs7c5) 做演示
