### PR TITLE
fix: ol-echarts@4.0.0 Cannot read properties of undefined (reading split) close #120

### DIFF
--- a/packages/ol-echarts/src/index.ts
+++ b/packages/ol-echarts/src/index.ts
@@ -1,4 +1,5 @@
-import { Map, Object as obj, VERSION } from 'ol';
+import { Map, Object as obj } from 'ol';
+import { VERSION } from 'ol/util';
 import { ProjectionLike, transform } from 'ol/proj';
 import Event from 'ol/events/Event';
 import { Coordinate } from 'ol/coordinate';

--- a/rollup/ol/external.js
+++ b/rollup/ol/external.js
@@ -1,5 +1,6 @@
 module.exports = [
   'ol',
+  'ol/util',
   'ol/layer',
   'ol/source',
   'ol/proj',

--- a/rollup/ol/globals.js
+++ b/rollup/ol/globals.js
@@ -1,7 +1,8 @@
 module.exports = {
-  'ol': 'ol',
+  ol: 'ol',
+  'ol/util': 'ol.util',
   'ol/layer': 'ol.layer',
   'ol/source': 'ol.source',
   'ol/proj': 'ol.proj',
-  'openlayers': 'ol',
+  openlayers: 'ol',
 };


### PR DESCRIPTION
(fix: ol-echarts@4.0.0 Cannot read properties of undefined (reading split) close #120)